### PR TITLE
Remove 1sec.mp3 code

### DIFF
--- a/main.py
+++ b/main.py
@@ -95,7 +95,7 @@ def alexa():
 			f.write(audio)
 		GPIO.output(lights[1], GPIO.LOW)
 
-		os.system('mpg123 -q {}1sec.mp3 {}response.mp3 /root/AlexaPi/1sec.mp3'.format(path, path))
+		os.system('mpg123 -q {}response.mp3'.format(path))
 		GPIO.output(lights[0], GPIO.LOW)
 	else:
 		GPIO.output(lights[1], GPIO.LOW)
@@ -142,7 +142,7 @@ if __name__ == "__main__":
 	while internet_on() == False:
 		print "."
 	token = gettoken()
-	os.system('mpg123 -q {}1sec.mp3 {}hello.mp3'.format(path, path))
+	os.system('mpg123 -q {}hello.mp3'.format(path))
 	for x in range(0, 3):
 		time.sleep(.1)
 		GPIO.output(lights[0], GPIO.HIGH)


### PR DESCRIPTION
1sec.mp3 playback causing message.mp3 to clip leading audio on an Pi Zero
